### PR TITLE
feat(catalog-filter): display translated color labels in filter and applied filters

### DIFF
--- a/src/components/catalog/color-filter.tsx
+++ b/src/components/catalog/color-filter.tsx
@@ -3,6 +3,7 @@ import { TRANSLATION_NAMESPACES } from "@/lib/i18n";
 import { useTranslation } from "react-i18next";
 import { Checkbox } from "../ui/checkbox";
 import { Label } from "../ui/label";
+import useLocale from "@/hooks/use-locale";
 
 type ColorFilterProps = {
   color?: string[];
@@ -16,16 +17,23 @@ const ColorFilter = ({
   toggleFilterValue,
 }: ColorFilterProps) => {
   const { t } = useTranslation(TRANSLATION_NAMESPACES.catalog);
+  const locale = useLocale();
   const colorOptions = Array.from(
-    new Set(
-      products.flatMap((product) =>
-        product.skus
-          .filter((sku) => sku.stock > 0 && sku.color)
-          .map((sku) => sku.color),
-      ),
-    ),
+    new Map(
+      products
+        .flatMap((product) =>
+          product.options.colors.map((colorOption) => ({
+            code: colorOption.code,
+            label: colorOption.label[locale],
+          })),
+        )
+        .map((option) => [option.code, option]),
+    ).values(),
   );
-  const selectedColors = color ?? [];
+
+  const selectedColors = Array.from(
+    new Set(color?.filter((v): v is string => !!v) ?? []),
+  );
   return (
     <div className="flex flex-col gap-2">
       <Label
@@ -36,17 +44,20 @@ const ColorFilter = ({
       </Label>
       <div id="color" className="grid grid-cols-2 gap-2">
         {colorOptions.map((option) => (
-          <div key={option} className="flex items-center gap-3">
+          <div key={option.code} className="flex items-center gap-3">
             <Checkbox
-              id={`color-${option}`}
-              checked={selectedColors.includes(option)}
+              id={`color-${option.code}`}
+              checked={selectedColors.includes(option.code)}
+              value={option.code}
               onCheckedChange={() => {
-                const next = toggleFilterValue(selectedColors, option);
+                const next = Array.from(
+                  new Set(toggleFilterValue(selectedColors, option.code)),
+                );
                 patchSearch({ color: next.length > 0 ? next : undefined });
               }}
             />
-            <Label htmlFor={`color-${option}`} className="cursor-pointer">
-              {option}
+            <Label htmlFor={`color-${option.code}`} className="cursor-pointer">
+              {option.label}
             </Label>
           </div>
         ))}

--- a/src/data/products.ts
+++ b/src/data/products.ts
@@ -9,6 +9,7 @@ import type {
 type OptionDef = {
   code: TypeCode;
   label: LocalizedString;
+  images?: string[];
 };
 
 type SizeOptionDef = {
@@ -44,11 +45,11 @@ const createTypeOptions = (
   productId: string,
   options: OptionDef[],
 ): ProductOption<TypeCode>[] => {
-  return options.map(({ code, label }) => ({
+  return options.map(({ code, label, images }) => ({
     id: `${productId}-type-${code}`,
     code,
     label,
-    images: [
+    images: images ?? [
       `https://placehold.co/600x800?text=${productId}+${code}+Front`,
       `https://placehold.co/600x800?text=${productId}+${code}+Back`,
     ],
@@ -121,6 +122,10 @@ export const products: Product[] = [
         {
           code: "white",
           label: { cs: "Bílé", en: "White" },
+          images: [
+            "https://m.media-amazon.com/images/I/61qC9IqwprL._AC_SX679_.jpg",
+            "https://m.media-amazon.com/images/I/61bigqtSm9L._AC_SX679_.jpg",
+          ],
         },
         {
           code: "black",

--- a/src/lib/product-utils.ts
+++ b/src/lib/product-utils.ts
@@ -337,6 +337,11 @@ const getAvailableSizes = (product: Product) => {
 const getAppliedFiltersLabel = (query: Query, locale: Languages) => {
   const labels: { label: string; key: string; removeValue?: string }[] = [];
   const t = i18n.getFixedT(locale, "catalog");
+  const colorLabelByCode = new Map(
+    products
+      .flatMap((product) => product.options.colors)
+      .map((colorOption) => [colorOption.code, colorOption.label[locale]]),
+  );
 
   if (query.category) {
     labels.push({
@@ -378,9 +383,11 @@ const getAppliedFiltersLabel = (query: Query, locale: Languages) => {
     }
   }
   if (query.color?.length) {
-    for (const selectedColor of query.color) {
+    const selectedColors = Array.from(new Set(query.color));
+
+    for (const selectedColor of selectedColors) {
       labels.push({
-        label: `${t("filters.color")}: ${selectedColor}`,
+        label: `${t("filters.color")}: ${colorLabelByCode.get(selectedColor) ?? selectedColor}`,
         key: "color",
         removeValue: selectedColor,
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color filter options now display localized, human-readable labels instead of raw codes.
  * Color options now support custom images for better visual representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->