### PR TITLE
fix: enforce square images and clamp descriptions

### DIFF
--- a/src/components/catalog/product-card.tsx
+++ b/src/components/catalog/product-card.tsx
@@ -48,13 +48,13 @@ const ProductCard = ({ product }: ProductCardProps) => {
         <img
           src={images.primary}
           alt={product.name[locale]}
-          className="max-h-100 md:max-h-80 lg:max-h-68 w-full object-cover aspect-square group-hover:hidden"
+          className="w-full object-cover aspect-square group-hover:hidden"
           loading="lazy"
         />
         <img
           src={images.secondary}
           alt={product.name[locale]}
-          className="max-h-100 md:max-h-80 lg:max-h-68 w-full object-cover aspect-square hidden group-hover:block"
+          className="w-full object-cover aspect-square hidden group-hover:block"
           loading="lazy"
         />
         <div className="absolute bottom-2 left-2 flex flex-col text-xs items-start gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity w-[calc(100%-1rem)]">

--- a/src/components/catalog/product-card.tsx
+++ b/src/components/catalog/product-card.tsx
@@ -48,13 +48,13 @@ const ProductCard = ({ product }: ProductCardProps) => {
         <img
           src={images.primary}
           alt={product.name[locale]}
-          className="max-h-100 md:max-h-80 lg:max-h-68 w-full object-cover group-hover:hidden"
+          className="max-h-100 md:max-h-80 lg:max-h-68 w-full object-cover aspect-square group-hover:hidden"
           loading="lazy"
         />
         <img
           src={images.secondary}
           alt={product.name[locale]}
-          className="max-h-100 md:max-h-80 lg:max-h-68 w-full object-cover hidden group-hover:block"
+          className="max-h-100 md:max-h-80 lg:max-h-68 w-full object-cover aspect-square hidden group-hover:block"
           loading="lazy"
         />
         <div className="absolute bottom-2 left-2 flex flex-col text-xs items-start gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity w-[calc(100%-1rem)]">
@@ -133,7 +133,9 @@ const ProductCard = ({ product }: ProductCardProps) => {
               {product.name[locale]}
             </Link>
           </h3>
-          <p className="text-muted-foreground">{product.description[locale]}</p>
+          <p className="text-muted-foreground line-clamp-3">
+            {product.description[locale]}
+          </p>
         </div>
         <div className="flex items-center justify-between">
           <p className="text-lg font-bold">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Product card images now display with a consistent square aspect ratio
  * Product descriptions are now limited to three lines with text truncation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->