### PR TITLE
feat: add translations and filter for admin dashboard sidebar

### DIFF
--- a/src/components/user/user-sidebar.tsx
+++ b/src/components/user/user-sidebar.tsx
@@ -1,5 +1,5 @@
 import { USER_MENU_ITEMS } from "@/constants";
-import { logout } from "@/lib/auth";
+import { hasRole, logout } from "@/lib/auth";
 import { TRANSLATION_NAMESPACES } from "@/lib/i18n";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
@@ -21,28 +21,33 @@ const UserSidebar = () => {
         </CardHeader>
         <CardContent>
           <nav className="flex flex-row md:flex-col gap-2 w-full justify-center md:justify-start">
-            {USER_MENU_ITEMS.map((item) => (
-              <Button
-                nativeButton={false}
-                key={item.path}
-                className="w-full p-0"
-                variant="ghost"
-                render={() => (
-                  <Link
-                    to={item.path}
-                    className="flex flex-col md:flex-row items-center px-3 py-2 rounded-md hover:bg-muted gap-2"
-                    activeProps={{ className: "bg-muted" }}
-                    activeOptions={{ exact: true }}
-                  >
-                    <item.icon
-                      className="inline-block text-primary"
-                      size={20}
-                    />
-                    {t(item.label)}
-                  </Link>
-                )}
-              />
-            ))}
+            {USER_MENU_ITEMS.map((item) => {
+              if (item.adminOnly && !hasRole("admin")) {
+                return null;
+              }
+              return (
+                <Button
+                  nativeButton={false}
+                  key={item.path}
+                  className="w-full p-0"
+                  variant="ghost"
+                  render={() => (
+                    <Link
+                      to={item.path}
+                      className="flex flex-col md:flex-row items-center px-3 py-2 rounded-md hover:bg-muted gap-2"
+                      activeProps={{ className: "bg-muted" }}
+                      activeOptions={{ exact: true }}
+                    >
+                      <item.icon
+                        className="inline-block text-primary"
+                        size={20}
+                      />
+                      {t(item.label)}
+                    </Link>
+                  )}
+                />
+              );
+            })}
             <Button
               nativeButton={false}
               className="w-full p-0 mt-2"

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -3,6 +3,7 @@ import type { DashboardMetricsKey, DashboardPeriod, Order } from "@/types";
 import {
   Banknote,
   HandCoins,
+  LayoutDashboard,
   LayoutTemplate,
   Shirt,
   ShoppingBag,
@@ -50,11 +51,19 @@ const USER_MENU_ITEMS: {
   icon: LucideIcon;
   label: `nav.${string}`;
   path: string;
+  adminOnly?: boolean;
 }[] = [
   {
     icon: ShoppingBag,
     label: "nav.orders",
     path: "/{-$locale}/account/orders",
+    adminOnly: false,
+  },
+  {
+    icon: LayoutDashboard,
+    label: "nav.admin",
+    path: "/{-$locale}/admin",
+    adminOnly: true,
   },
 ];
 

--- a/src/locales/cs/account.json
+++ b/src/locales/cs/account.json
@@ -2,6 +2,7 @@
   "title": "Účet",
   "nav": {
     "orders": "Mé Objednávky",
+    "admin": "Admin Dashboard",
     "logout": "Odhlásit se"
   },
   "orders": {

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -2,6 +2,7 @@
   "title": "Account",
   "nav": {
     "orders": "My Orders",
+    "admin": "Admin Dashboard",
     "logout": "Logout"
   },
   "orders": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin users can now access the Admin Dashboard directly from the user sidebar menu. The menu item is conditionally displayed based on authorization, ensuring non-admin users do not see this option. Includes localized labels in multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->