### PR TITLE
fix: add justify-items-stretch for catalog and full width layout

### DIFF
--- a/src/components/catalog/catalog-products.tsx
+++ b/src/components/catalog/catalog-products.tsx
@@ -11,7 +11,7 @@ const CatalogProducts = ({ products }: CatalogProductsProps) => {
   const { t } = useTranslation(TRANSLATION_NAMESPACES.catalog);
 
   return (
-    <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+    <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 justify-items-stretch w-full">
       {products.length === 0 && (
         <div className="text-center text-muted-foreground col-span-full min-h-80 py-16 ">
           <p>{t("catalog.noResults")}</p>

--- a/src/components/catalog/product-card.tsx
+++ b/src/components/catalog/product-card.tsx
@@ -41,7 +41,7 @@ const ProductCard = ({ product }: ProductCardProps) => {
 
   return (
     <Card
-      className="p-0 shadow-sm gap-2 overflow-hidden group max-w-sm w-full max-h-fit"
+      className="p-0 shadow-sm gap-2 overflow-hidden group w-full"
       key={product.id}
     >
       <CardHeader className="p-0 relative">
@@ -133,7 +133,7 @@ const ProductCard = ({ product }: ProductCardProps) => {
               {product.name[locale]}
             </Link>
           </h3>
-          <p className="text-muted-foreground line-clamp-3">
+          <p className="text-muted-foreground line-clamp-2">
             {product.description[locale]}
           </p>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted catalog grid layout for improved item spacing and distribution
  * Updated product card width styling for full-width display
  * Reduced product description preview to show 2 lines instead of 3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->