### PR TITLE
feat: add coming soon toast for inactive links

### DIFF
--- a/src/components/form/login-form.tsx
+++ b/src/components/form/login-form.tsx
@@ -138,6 +138,7 @@ export function LoginForm({
                   </FieldLabel>
                   <Link
                     to="."
+                    disabled
                     tabIndex={-1}
                     className="ml-auto text-sm underline-offset-2 hover:underline"
                     onClick={sendComingSoonToast}
@@ -200,6 +201,7 @@ export function LoginForm({
                 {t("login.doesNotHaveAccount")}{" "}
                 <Link
                   to="."
+                  disabled
                   className="hover:underline"
                   onClick={sendComingSoonToast}
                 >
@@ -218,6 +220,7 @@ export function LoginForm({
             terms: (
               <Link
                 to="."
+                disabled
                 className="underline"
                 onClick={sendComingSoonToast}
               />
@@ -225,6 +228,7 @@ export function LoginForm({
             privacy: (
               <Link
                 to="."
+                disabled
                 className="underline"
                 onClick={sendComingSoonToast}
               />

--- a/src/components/form/login-form.tsx
+++ b/src/components/form/login-form.tsx
@@ -19,6 +19,7 @@ import toast from "react-hot-toast";
 import { Trans, useTranslation } from "react-i18next";
 import { Checkbox } from "../ui/checkbox";
 import { MIN_PASSWORD_LENGTH } from "@/constants";
+import { showInfoToast } from "@/lib/toasts";
 
 type FieldErrors = {
   email?: string;
@@ -75,6 +76,10 @@ export function LoginForm({
     }
 
     await loginAsync(result.data);
+  };
+
+  const sendComingSoonToast = () => {
+    showInfoToast(t("common:toast.comingSoon"));
   };
 
   return (
@@ -135,6 +140,7 @@ export function LoginForm({
                     to="."
                     tabIndex={-1}
                     className="ml-auto text-sm underline-offset-2 hover:underline"
+                    onClick={sendComingSoonToast}
                   >
                     {t("login.fields.forgotPassword")}
                   </Link>
@@ -192,7 +198,11 @@ export function LoginForm({
 
               <FieldDescription className="text-center">
                 {t("login.doesNotHaveAccount")}{" "}
-                <Link to="." className="hover:underline">
+                <Link
+                  to="."
+                  className="hover:underline"
+                  onClick={sendComingSoonToast}
+                >
                   {t("login.register")}
                 </Link>
               </FieldDescription>
@@ -205,8 +215,20 @@ export function LoginForm({
           ns={TRANSLATION_NAMESPACES.auth}
           i18nKey="login.conditions"
           components={{
-            terms: <Link to="." className="underline" />,
-            privacy: <Link to="." className="underline" />,
+            terms: (
+              <Link
+                to="."
+                className="underline"
+                onClick={sendComingSoonToast}
+              />
+            ),
+            privacy: (
+              <Link
+                to="."
+                className="underline"
+                onClick={sendComingSoonToast}
+              />
+            ),
           }}
         />
       </FieldDescription>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Login form placeholder links (Forgot Password, Register, Terms, Privacy) now show a localized "coming soon" info toast when clicked, giving users clear feedback that those features or pages are not yet available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/florixak/rtsoft-clothing-eshop/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->